### PR TITLE
[기능개발] 검색기능에서 stack 관련 필터링 추가 #34

### DIFF
--- a/src/main/java/com/example/itmonster/controller/request/QuestRequestDto.java
+++ b/src/main/java/com/example/itmonster/controller/request/QuestRequestDto.java
@@ -18,5 +18,6 @@ public class QuestRequestDto {
     private Long designer;
 
     private Long duration; // 주단위로 기간 설정
-    // 기술스택 추가 해야됨 !!
+
+    private String stacks;
 }

--- a/src/main/java/com/example/itmonster/controller/response/SearchResponseDto.java
+++ b/src/main/java/com/example/itmonster/controller/response/SearchResponseDto.java
@@ -1,6 +1,9 @@
 package com.example.itmonster.controller.response;
 
 import com.example.itmonster.domain.Quest;
+import com.example.itmonster.domain.StackOfQuest;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +27,9 @@ public class SearchResponseDto {
 
     private Long duration;
 
-    public SearchResponseDto( Quest quest ){
+    private List<StackDto> stacks;
+
+    public SearchResponseDto( Quest quest , List<StackOfQuest> stacks ){
         questId = quest.getId();
         title = quest.getTitle();
         content = quest.getContent();
@@ -38,6 +43,11 @@ public class SearchResponseDto {
         designer = quest.getDesigner();
 
         duration = quest.getDuration();
+
+        List<StackDto> stackDtoList = new ArrayList<>();
+        stacks.forEach( stack -> stackDtoList.add( new StackDto( stack )));
+
+        this.stacks = stackDtoList;
 
     }
 

--- a/src/main/java/com/example/itmonster/controller/response/StackDto.java
+++ b/src/main/java/com/example/itmonster/controller/response/StackDto.java
@@ -1,0 +1,17 @@
+package com.example.itmonster.controller.response;
+
+import com.example.itmonster.domain.StackOfQuest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StackDto {
+    private String stackName;
+
+    public StackDto( StackOfQuest stack ){
+        stackName = stack.getStackName();
+    }
+}

--- a/src/main/java/com/example/itmonster/domain/StackOfQuest.java
+++ b/src/main/java/com/example/itmonster/domain/StackOfQuest.java
@@ -1,0 +1,36 @@
+package com.example.itmonster.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StackOfQuest {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY )
+    private Long Id;
+
+    @Column( nullable = false )
+    private String stackName;
+
+    @JoinColumn
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Quest quest;
+
+}

--- a/src/main/java/com/example/itmonster/repository/StackOfQuestRepository.java
+++ b/src/main/java/com/example/itmonster/repository/StackOfQuestRepository.java
@@ -1,0 +1,11 @@
+package com.example.itmonster.repository;
+
+import com.example.itmonster.domain.Quest;
+import com.example.itmonster.domain.StackOfQuest;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StackOfQuestRepository extends JpaRepository<StackOfQuest,Long> {
+
+    List<StackOfQuest> findAllByQuest(Quest result);
+}

--- a/src/main/java/com/example/itmonster/utils/SearchPredicate.java
+++ b/src/main/java/com/example/itmonster/utils/SearchPredicate.java
@@ -1,18 +1,35 @@
 package com.example.itmonster.utils;
 
 import com.example.itmonster.domain.QQuest;
+import com.example.itmonster.domain.QStackOfQuest;
+import com.example.itmonster.domain.Quest;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import org.springframework.util.MultiValueMap;
 
 
 public class SearchPredicate {
 
-    public static BooleanBuilder filter( MultiValueMap<String, String> allParameters ){
+    public static BooleanBuilder filter( MultiValueMap<String, String> allParameters , JPAQueryFactory jpaQueryFactory){
 
         BooleanBuilder searchBuilder = new BooleanBuilder();
         QQuest quest = QQuest.quest;
+        QStackOfQuest stackOfQuest = QStackOfQuest.stackOfQuest;
 
        // 시간나면 BooleanExpress 형태로 리팩토링할 예정
+
+        //stack 필터
+        if( allParameters.get("stack") != null ){
+            List<String> stacks = allParameters.get("stack");
+            List<Quest> quests = jpaQueryFactory.select( stackOfQuest.quest )
+                .from( stackOfQuest )
+                .where( stackOfQuest.stackName.in( stacks ) )
+                .groupBy( stackOfQuest.quest )
+                .having( stackOfQuest.count().eq((long) stacks.size()) ).fetch();
+
+            searchBuilder.and( quest.in( quests ) );
+        }
 
         // duration 필터
         if (allParameters.get("duration") != null) {


### PR DESCRIPTION
1. stackOfQuest 엔티티 생성
2. quest 작성 시 stack 입력할 때 "스택명" + " " 로 입력한다. ( ex : "stacks":"SpringBoot Vue.js Mysql " )
3.  각 스택들은 모두 and 조건으로 연결됨 ( 필터로 설정된 스택들이 '모두' 포함된 퀘스트들을 검색 ) 
4. 현재 stackName은 string으로 받고 있음. 추후 enum으로 변경할 계획이 있음