### PR TITLE
[기능개발] 검색기능 필터 일부 수정, 스쿼드 관련 엔티티 및 API 수정 issue#55

### DIFF
--- a/src/main/java/com/example/itmonster/controller/response/SquadResponseDto.java
+++ b/src/main/java/com/example/itmonster/controller/response/SquadResponseDto.java
@@ -19,14 +19,11 @@ public class SquadResponseDto {
 
     private Long memberId;
 
-    private ClassType classType;
-
     public SquadResponseDto( Squad squad ){
         squadId = squad.getId();
         questId = squad.getQuest().getId();
         questTitle = squad.getQuest().getTitle();
         memberId = squad.getMember().getId();
-        classType = squad.getClassType();
     }
 
 

--- a/src/main/java/com/example/itmonster/domain/Squad.java
+++ b/src/main/java/com/example/itmonster/domain/Squad.java
@@ -31,7 +31,4 @@ public class Squad {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
-    @Column( nullable = false )
-    private ClassType classType;
-
 }

--- a/src/main/java/com/example/itmonster/service/SquadService.java
+++ b/src/main/java/com/example/itmonster/service/SquadService.java
@@ -50,7 +50,6 @@ public class SquadService {
             Squad.builder()
                 .quest( quest )
                 .member( offeredMember )
-                .classType( classType )
                 .build()
         );
 

--- a/src/main/java/com/example/itmonster/utils/SearchPredicate.java
+++ b/src/main/java/com/example/itmonster/utils/SearchPredicate.java
@@ -20,11 +20,12 @@ public class SearchPredicate {
             .where( containsTitle( allParameters.get("title") ),
                 containsContent( allParameters.get("content") ),
                 loeDuration( allParameters.get("duration") ),
-                loeBackend( allParameters.get("backend") ),
-                loeFrontend( allParameters.get("frontend") ),
-                loeFullstack( allParameters.get("fullstack") ),
-                loeDesigner( allParameters.get("designer") ),
+                containsBackend( allParameters.get("classType") ),
+                containsFrontend( allParameters.get("classType") ),
+                containsFullstack( allParameters.get("classType") ),
+                containsDesigner( allParameters.get("classType") ),
                 inStacks( allParameters.get("stack")) )
+            .orderBy( quest.modifiedAt.desc() )
             .fetch();
     }
 
@@ -47,26 +48,31 @@ public class SearchPredicate {
     }
 
     // 프.백.풀.디 인원수 필터
-    private static BooleanExpression loeFrontend(List<String> frontend_num){
-        return frontend_num != null ?
-            quest.frontend.between( 1,  Long.parseLong(frontend_num.get(0)) ) : null;
+    private static BooleanExpression containsFrontend(List<String> classType ){
+        return classType != null && classType.contains( "frontend" )?
+            quest.frontend.goe( 1 ) : null;
     }
 
-    private static BooleanExpression loeBackend(List<String> backend_num ){
-        return backend_num != null ?
-            quest.backend.between( 1, Long.parseLong(backend_num.get(0)) ) : null;
+    private static BooleanExpression containsBackend(List<String> classType ){
+        return classType != null && classType.contains( "backend" )?
+            quest.backend.goe( 1 ) : null;
     }
 
-    private static BooleanExpression loeFullstack(List<String> fullstack_num ){
-        return fullstack_num != null ?
-            quest.fullstack.between( 1, Long.parseLong(fullstack_num.get(0)) ) : null;
+    private static BooleanExpression containsFullstack(List<String> classType ){
+        return classType != null && classType.contains( "fullstack" )?
+            quest.fullstack.goe( 1 ) : null;
     }
 
-    private static BooleanExpression loeDesigner(List<String> designer_num ){
-        return designer_num != null ?
-            quest.designer.between( 1, Long.parseLong(designer_num.get(0)) ) : null;
+    private static BooleanExpression containsDesigner(List<String> classType ){
+        return classType != null && classType.contains( "designer" )?
+            quest.designer.goe( 1 ) : null;
     }
-
+//
+//    private static BooleanExpression containsClass(List<String> classType ){
+//        return classType != null ?
+//            containsFrontend( classType ).and( containsBackend(classType) )
+//                .and( containsDesigner( classType ) ).and( containsFullstack( classType)) : null;
+//    }
     // 스택 필터
     private static BooleanExpression inStacks( List<String> stacks ){
         if( stacks == null ) return null;
@@ -77,4 +83,5 @@ public class SearchPredicate {
                 .groupBy( stackOfQuest.quest )
                 .having( stackOfQuest.count().eq((long) stacks.size())) ) ;
     }
+
 }


### PR DESCRIPTION
1.백엔드, 프론트엔드 등의 특정 인원수 이하를 검색하는 것에서 다음과 같이 변경
>필터에서 클래스타입( 백엔드,프론트엔드 등 )을 다중 선택하면 선택한 클래스타입들의 모집인원이 각각 1 이상인 게시글들만 검색되도록 수정.
파라미터 : ex) search?classType=backend&classType=frontend

2. 스쿼드 엔티티에서 classType을 추가했던 부분을 다시 롤백